### PR TITLE
Support Package 1

### DIFF
--- a/src/Deveel.Results/OperationErrorExtensions.cs
+++ b/src/Deveel.Results/OperationErrorExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace Deveel
+{
+    /// <summary>
+    /// Extends the <see cref="IOperationError"/> contract to provide
+    /// additional functionality.
+    /// </summary>
+    public static class OperationErrorExtensions
+    {
+        /// <summary>
+        /// Converts the error to an operation exception.
+        /// </summary>
+        /// <param name="error">
+        /// The error to convert to an exception.
+        /// </param>
+        /// <returns>
+        /// Returns an instance of <see cref="OperationException"/> that
+        /// represents the error.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the <paramref name="error"/> is <see langword="null"/>.
+        /// </exception>
+        public static OperationException AsException(this IOperationError error)
+        {
+            ArgumentNullException.ThrowIfNull(error, nameof(error));
+            return new OperationException(error.Code, error.Domain, error.Message, error.InnerError?.AsException());
+        }
+    }
+}

--- a/src/Deveel.Results/OperationResult.cs
+++ b/src/Deveel.Results/OperationResult.cs
@@ -31,11 +31,6 @@ namespace Deveel
         public static readonly OperationResult NotChanged = new(OperationResultType.Unchanged, null);
 
         /// <summary>
-        /// The result of an operation that has been cancelled.
-        /// </summary>
-        public static readonly OperationResult Cancelled = new(OperationResultType.Cancelled, null);
-
-        /// <summary>
         /// Creates a new instance of an operation result that has failed.
         /// </summary>
         /// <param name="error">

--- a/src/Deveel.Results/OperationResultExtensions.cs
+++ b/src/Deveel.Results/OperationResultExtensions.cs
@@ -197,5 +197,130 @@ namespace Deveel
 
             throw new InvalidOperationException("The operation result is in an unknown state.");
         }
+
+        /// <summary>
+        /// Attempts to match the operation result to a specific state
+        /// that can be handled by the caller.
+        /// </summary>
+        /// <typeparam name="TResult">
+        /// The type of the result that is returned by the match.
+        /// </typeparam>
+        /// <param name="result">
+        /// The operation result to match.
+        /// </param>
+        /// <param name="ifSuccess">
+        /// A function that is called when the operation result was a success.
+        /// </param>
+        /// <param name="ifError">
+        /// A function that is called when the operation result was an error.
+        /// </param>
+        /// <param name="ifUnchanged">
+        /// A function that is called when the operation result caused no changed
+        /// to the object.
+        /// </param>
+        /// <returns>
+        /// Returns the result of the function that was called based on the state
+        /// of the operation result.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the operation result is in an unknown state.
+        /// </exception>
+        public static TResult Match<T, TResult>(this IOperationResult<T> result,
+            Func<T?, TResult>? ifSuccess = null,
+            Func<IOperationError?, TResult>? ifError = null,
+            Func<T?, TResult>? ifUnchanged = null)
+        {
+            ArgumentNullException.ThrowIfNull(result, nameof(result));
+
+            if (result.IsSuccess())
+            {
+                ArgumentNullException.ThrowIfNull(ifSuccess, nameof(ifSuccess));
+                return ifSuccess(result.Value);
+            }
+
+            if (result.IsError())
+            {
+                ArgumentNullException.ThrowIfNull(ifError, nameof(ifError));
+                return ifError(result.Error);
+            }
+
+            if (result.IsUnchanged())
+            {
+                ArgumentNullException.ThrowIfNull(ifUnchanged, nameof(ifUnchanged));
+                return ifUnchanged(result.Value);
+            }
+
+            throw new InvalidOperationException("The operation result is in an unknown state.");
+        }
+
+        /// <summary>
+        /// Attempts to match the operation result to a specific state
+        /// that can be handled by the caller.
+        /// </summary>
+        /// <typeparam name="TResult">
+        /// The type of the result that is returned by the match.
+        /// </typeparam>
+        /// <param name="result">
+        /// The operation result to match.
+        /// </param>
+        /// <param name="ifSuccess">
+        /// A function that is called when the operation result was a success.
+        /// </param>
+        /// <param name="ifError">
+        /// A function that is called when the operation result was an error.
+        /// </param>
+        /// <param name="ifUnchanged">
+        /// A function that is called when the operation result caused no changed
+        /// to the object.
+        /// </param>
+        /// <returns>
+        /// Returns the result of the function that was called based on the state
+        /// of the operation result.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the operation result is in an unknown state.
+        /// </exception>
+        public static Task<TResult> MatchAsync<T, TResult>(this IOperationResult<T> result,
+            Func<T?, Task<TResult>>? ifSuccess = null,
+            Func<IOperationError?, Task<TResult>>? ifError = null,
+            Func<T?, Task<TResult>>? ifUnchanged = null)
+        {
+            ArgumentNullException.ThrowIfNull(result, nameof(result));
+
+            if (result.IsSuccess())
+            {
+                ArgumentNullException.ThrowIfNull(ifSuccess, nameof(ifSuccess));
+                return ifSuccess(result.Value);
+            }
+
+            if (result.IsError())
+            {
+                ArgumentNullException.ThrowIfNull(ifError, nameof(ifError));
+                return ifError(result.Error);
+            }
+
+            if (result.IsUnchanged())
+            {
+                ArgumentNullException.ThrowIfNull(ifUnchanged, nameof(ifUnchanged));
+                return ifUnchanged(result.Value);
+            }
+
+            throw new InvalidOperationException("The operation result is in an unknown state.");
+        }
+
+
+
+        /// <summary>
+        /// Converts an error result to an exception.
+        /// </summary>
+        /// <param name="result"></param>
+        /// <returns></returns>
+        public static OperationException? AsException(this IOperationResult result)
+        {
+            if (!result.IsError() || result.Error == null)
+                return null;
+
+            return result.Error.AsException();
+        }
     }
 }

--- a/src/Deveel.Results/OperationResultExtensions.cs
+++ b/src/Deveel.Results/OperationResultExtensions.cs
@@ -34,19 +34,6 @@ namespace Deveel
             => result.ResultType == OperationResultType.Error;
 
         /// <summary>
-        /// Determines if the operation result is cancelled.
-        /// </summary>
-        /// <param name="result">
-        /// The operation result to check.
-        /// </param>
-        /// <returns>
-        /// Returns <see langword="true"/> if the operation result is cancelled,
-        /// otherwise <see langword="false"/>.
-        /// </returns>
-        public static bool IsCancelled(this IOperationResult result)
-            => result.ResultType == OperationResultType.Cancelled;
-
-        /// <summary>
         /// Determines if the operation has caused no changes
         /// to the state of an object.
         /// </summary>

--- a/src/Deveel.Results/OperationResultType.cs
+++ b/src/Deveel.Results/OperationResultType.cs
@@ -23,11 +23,6 @@
         /// <summary>
         /// The operation caused no changes.
         /// </summary>
-        Unchanged = 3,
-
-        /// <summary>
-        /// The operation was cancelled.
-        /// </summary>
-        Cancelled = 4
+        Unchanged = 3
     }
 }

--- a/src/Deveel.Results/OperationResult_T.cs
+++ b/src/Deveel.Results/OperationResult_T.cs
@@ -27,12 +27,6 @@ namespace Deveel
         public IOperationError? Error { get; }
 
         /// <summary>
-        /// A result of an operation that has not changed the state 
-        /// of an object.
-        /// </summary>
-        public static readonly OperationResult<T> NotChanged = new(OperationResultType.Unchanged, default, null);
-
-        /// <summary>
         /// A result of an operation that has been cancelled.
         /// </summary>
         public static readonly OperationResult<T> Cancelled = new(OperationResultType.Cancelled, default, null);
@@ -49,6 +43,21 @@ namespace Deveel
         {
             return new OperationResult<T>(OperationResultType.Success, value, null);
         }
+
+        /// <summary>
+        /// Creates a new instance of an operation result that has caused
+        /// no change in the state of an object.
+        /// </summary>
+        /// <param name="value">
+        /// The value that represents the object that was attempted
+        /// to be changed.
+        /// </param>
+        /// <returns>
+        /// Returns an instance of <see cref="OperationResult{T}"/> that
+        /// represents an unchanged operation.
+        /// </returns>
+        public static OperationResult<T> NotChanged(T? value = default) 
+            => new(OperationResultType.Unchanged, value, null);
 
         /// <summary>
         /// Creates a new instance of an operation result that has failed
@@ -153,5 +162,19 @@ namespace Deveel
         /// </param>
         /// <seealso cref="Fail(IOperationError)"/>
         public static implicit operator OperationResult<T>(OperationException error) => Fail(error);
+
+        /// <summary>
+        /// Implicitly converts the result to is value
+        /// </summary>
+        /// <param name="result">
+        /// The operation result that encapsulates the value to convert to.
+        /// </param>
+        public static implicit operator T?(OperationResult<T> result)
+        {
+            if (result.IsError())
+                throw result.AsException()!;
+
+            return result.Value;
+        }
     }
 }

--- a/src/Deveel.Results/OperationResult_T.cs
+++ b/src/Deveel.Results/OperationResult_T.cs
@@ -27,11 +27,6 @@ namespace Deveel
         public IOperationError? Error { get; }
 
         /// <summary>
-        /// A result of an operation that has been cancelled.
-        /// </summary>
-        public static readonly OperationResult<T> Cancelled = new(OperationResultType.Cancelled, default, null);
-
-        /// <summary>
         /// Creates a new instance of an operation result that has succeeded
         /// with the given value.
         /// </summary>

--- a/test/Deveel.Results.XUnit/OperationResultOfTTests.cs
+++ b/test/Deveel.Results.XUnit/OperationResultOfTTests.cs
@@ -52,15 +52,6 @@ namespace Deveel
 
 
         [Fact]
-        public static void OperationResultOfT_Cancelled()
-        {
-            var result = OperationResult<int>.Cancelled;
-            Assert.Equal(OperationResultType.Cancelled, result.ResultType);
-            Assert.Null(result.Error);
-            Assert.Equal(default, result.Value);
-        }
-
-        [Fact]
         public static void OperationResult_FailWithCode()
         {
             var result = OperationResult<int>.Fail("err.1", "biz");

--- a/test/Deveel.Results.XUnit/OperationResultOfTTests.cs
+++ b/test/Deveel.Results.XUnit/OperationResultOfTTests.cs
@@ -35,11 +35,21 @@ namespace Deveel
         [Fact]
         public static void OperationResultOfT_NotChanged()
         {
-            var result = OperationResult<int>.NotChanged;
+            var result = OperationResult<int>.NotChanged();
             Assert.Equal(OperationResultType.Unchanged, result.ResultType);
             Assert.Null(result.Error);
             Assert.Equal(default, result.Value);
         }
+
+        [Fact]
+        public static void OperationResultOfT_WithValue_NotChanged()
+        {
+            var result = OperationResult<int>.NotChanged(33);
+            Assert.Equal(OperationResultType.Unchanged, result.ResultType);
+            Assert.Null(result.Error);
+            Assert.Equal(33, result.Value);
+        }
+
 
         [Fact]
         public static void OperationResultOfT_Cancelled()
@@ -174,6 +184,132 @@ namespace Deveel
 
             Assert.Equal(validations.Length, opError.ValidationResults.Count);
         }
+
+        [Fact]
+        public static void OperationResult_Fail_AsException()
+        {
+            var error = new OperationError("err.1", "test", "An error has occurred");
+            var result = OperationResult<int>.Fail(error);
+
+            var ex = result.AsException();
+
+            Assert.True(result.IsError());
+            Assert.NotNull(ex);
+            Assert.Equal(error.Code, ex.ErrorCode);
+            Assert.Equal(error.Domain, ex.ErrorDomain);
+            Assert.Equal(error.Message, ex.Message);
+        }
+
+        [Fact]
+        public static void OperationResult_FailWithInnerError_AsException()
+        {
+            var inner = new OperationError("err.0", "test", "Because of this error");
+            var error = new OperationError("err.1", "test", "An error as occurred", inner);
+
+            var result = OperationResult<int>.Fail(error);
+
+            var ex = result.AsException();
+
+            Assert.NotNull(ex);
+
+            Assert.True(result.IsError());
+            Assert.False(result.HasValidationErrors());
+
+            Assert.Equal(error.Code, ex.ErrorCode);
+            Assert.Equal(error.Domain, ex.ErrorDomain);
+            Assert.Equal(error.Message, ex.Message);
+            Assert.NotNull(ex.InnerException);
+
+            var innerEx = Assert.IsType<OperationException>(ex.InnerException);
+
+            Assert.NotNull(innerEx);
+            Assert.Equal(inner.Code, innerEx.ErrorCode);
+            Assert.Equal(inner.Domain, innerEx.ErrorDomain);
+            Assert.Equal(inner.Message, innerEx.Message);
+            Assert.Null(innerEx.InnerException);
+        }
+
+        [Fact]
+        public static void OperationResult_Success_AsException()
+        {
+            var result = OperationResult<int>.Success(34);
+
+            var ex = result.AsException();
+
+            Assert.False(result.IsError());
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public static void OperationResult_SuccessWithResult_ImplicitConvert()
+        {
+            var result = OperationResult<int>.Success(42);
+
+            int value = result;
+
+            Assert.Equal(42, value);
+        }
+
+        [Fact]
+        public static void OperationResult_Fail_ImplicitConvert()
+        {
+            var result = OperationResult<int>.Fail("err.1", "test", "An error has occurred");
+
+            Assert.Throws<OperationException>(() => {
+                int value = result;
+            });
+        }
+
+        [Fact]
+        public static void Match_Success()
+        {
+            var result = OperationResult<int>.Success(42);
+            var value = result.Match(r => $"The result is {r}");
+            Assert.Equal("The result is 42", value);
+        }
+
+        [Fact]
+        public static void Match_Error()
+        {
+            var error = new OperationError("err.1", "biz");
+            var result = OperationResult<int>.Fail(error);
+            var value = result.Match(ifError: e => $"The error {e.Code} was generated in domain {e.Domain}");
+            Assert.Equal("The error err.1 was generated in domain biz", value);
+        }
+
+        [Fact]
+        public static void Match_Unchanged()
+        {
+            var result = OperationResult<int>.NotChanged(33);
+            var value = result.Match(x => 42, ifUnchanged: x => 0);
+            Assert.Equal(0, value);
+        }
+
+        [Fact]
+        public static async Task MatchAsync_Success()
+        {
+            var result = OperationResult<int>.Success(42);
+            var value = await result.MatchAsync(r => Task.FromResult<string>($"The result is {r}"));
+            Assert.Equal("The result is 42", value);
+        }
+
+        [Fact]
+        public static async Task MatchAsync_Error()
+        {
+            var error = new OperationError("err.1", "biz");
+            var result = OperationResult<int>.Fail(error);
+            var value = await result.MatchAsync(ifError: e => Task.FromResult($"The error {e.Code} was generated in domain {e.Domain}"));
+            Assert.Equal("The error err.1 was generated in domain biz", value);
+        }
+
+        [Fact]
+        public static async Task MatchAsync_Unchanged()
+        {
+            var result = OperationResult<int>.NotChanged(11);
+            var value = await result.MatchAsync(r => Task.FromResult(r), ifUnchanged: r => Task.FromResult(0));
+            Assert.Equal(0, value);
+        }
+
 
         class DomainException : OperationException
         {

--- a/test/Deveel.Results.XUnit/OperationResultTests.cs
+++ b/test/Deveel.Results.XUnit/OperationResultTests.cs
@@ -216,4 +216,60 @@ public static class OperationResultTests
         Assert.True(result.HasValidationErrors());
         Assert.Equal(errors, result.ValidationResults());
     }
+
+    [Fact]
+    public static void OperationResult_Fail_AsException()
+    {
+        var error = new OperationError("err.1", "test", "An error has occurred");
+        var result = OperationResult.Fail(error);
+
+        var ex = result.AsException();
+
+        Assert.True(result.IsError());
+        Assert.NotNull(ex);
+        Assert.Equal(error.Code, ex.ErrorCode);
+        Assert.Equal(error.Domain, ex.ErrorDomain);
+        Assert.Equal(error.Message, ex.Message);
+    }
+
+    [Fact]
+    public static void OperationResult_FailWithInnerError_AsException()
+    {
+        var inner = new OperationError("err.0", "test", "Because of this error");
+        var error = new OperationError("err.1", "test", "An error as occurred", inner);
+
+        var result = OperationResult.Fail(error);
+
+        var ex = result.AsException();
+
+        Assert.NotNull(ex);
+
+        Assert.True(result.IsError());
+        Assert.False(result.HasValidationErrors());
+
+        Assert.Equal(error.Code, ex.ErrorCode);
+        Assert.Equal(error.Domain, ex.ErrorDomain);
+        Assert.Equal(error.Message, ex.Message);
+        Assert.NotNull(ex.InnerException);
+
+        var innerEx = Assert.IsType<OperationException>(ex.InnerException);
+
+        Assert.NotNull(innerEx);
+        Assert.Equal(inner.Code, innerEx.ErrorCode);
+        Assert.Equal(inner.Domain, innerEx.ErrorDomain);
+        Assert.Equal(inner.Message, innerEx.Message);
+        Assert.Null(innerEx.InnerException);
+    }
+
+    [Fact]
+    public static void OperationResult_Success_AsException()
+    {
+        var result = OperationResult.Success;
+
+        var ex = result.AsException();
+
+        Assert.False(result.IsError());
+        Assert.Null(ex);
+    }
+
 }

--- a/test/Deveel.Results.XUnit/OperationResultTests.cs
+++ b/test/Deveel.Results.XUnit/OperationResultTests.cs
@@ -23,14 +23,6 @@ public static class OperationResultTests
     }
 
     [Fact]
-    public static void OperationResult_Cancelled()
-    {
-        var result = OperationResult.Cancelled;
-        Assert.Equal(OperationResultType.Cancelled, result.ResultType);
-        Assert.Null(result.Error);
-    }
-
-    [Fact]
     public static void OperationResult_Fail()
     {
         var error = new OperationError("err.1", "biz");
@@ -171,13 +163,6 @@ public static class OperationResultTests
         var error = new OperationError("err.1", "biz");
         var result = OperationResult.Fail(error);
         Assert.True(result.IsError());
-    }
-
-    [Fact]
-    public static void OperationResult_IsCancelled()
-    {
-        var result = OperationResult.Cancelled;
-        Assert.True(result.IsCancelled());
     }
 
     [Fact]


### PR DESCRIPTION
Changes to the model of the results

* Removal of the _Cancelled_ state (and all methods related)
* Implicit conversations from `IOperationResult<T>` and `T`
* Shortcut to convert `IOperationError` to `OperationException`
* `Match` and `MatchAsync` versions to support `IOperationResult<T>` as argument