### PR TITLE
Add Bind and Tap extensions for IOperationResult with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea

--- a/src/Deveel.Results/ExceptionExtensions.cs
+++ b/src/Deveel.Results/ExceptionExtensions.cs
@@ -1,0 +1,42 @@
+namespace Deveel;
+
+/// <summary>
+/// Provides extension methods for <see cref="Exception"/> to facilitate
+/// integration with the result-oriented pattern.
+/// </summary>
+public static class ExceptionExtensions
+{
+    /// <summary>
+    /// Converts an <see cref="Exception"/> to an <see cref="IOperationError"/>,
+    /// enabling exceptions to be used in result-oriented pipelines.
+    /// </summary>
+    /// <param name="exception">
+    /// The exception to convert. If the exception already implements
+    /// <see cref="IOperationError"/>, it is returned as-is.
+    /// </param>
+    /// <param name="code">
+    /// An optional error code to assign to the resulting error.
+    /// Defaults to <c>"ERROR"</c> when not specified or when an empty value is provided.
+    /// </param>
+    /// <param name="domain">
+    /// An optional domain (namespace) to associate with the error.
+    /// When not specified, the namespace of the exception type is used.
+    /// </param>
+    /// <returns>
+    /// Returns an <see cref="IOperationError"/> that represents the exception.
+    /// If the exception already implements <see cref="IOperationError"/>, the
+    /// original instance is returned unchanged; otherwise a new <see cref="OperationError"/>
+    /// is created using the exception message and, when present, the inner exception
+    /// is recursively converted and set as the cause of the error.
+    /// </returns>
+    public static IOperationError AsOperationError(this Exception exception, string code = "ERROR", string? domain = null) {
+        if (exception is IOperationError operationError)
+            return operationError;
+        
+        if (string.IsNullOrWhiteSpace(code))
+            code = "ERROR";
+        
+        domain ??= exception.GetType().Namespace!;
+        return new OperationError(code, domain, exception.Message, exception.InnerException?.AsOperationError(domain: domain));
+    }
+}

--- a/src/Deveel.Results/OperationResultExtensions.cs
+++ b/src/Deveel.Results/OperationResultExtensions.cs
@@ -90,7 +90,442 @@ namespace Deveel
         /// </returns>
         public static IReadOnlyList<ValidationResult> ValidationResults(this IOperationResult result) 
             => result.HasValidationErrors() ? ((IValidationError)result.Error!).ValidationResults : Array.Empty<ValidationResult>();
+        
+        
+        /// <summary>
+        /// Executes the given function if the operation result is a success,
+        /// binding the result of the function to the current result chain.
+        /// </summary>
+        /// <param name="result">
+        /// The operation result to evaluate.
+        /// </param>
+        /// <param name="func">
+        /// A function to invoke when the operation result is a success.
+        /// </param>
+        /// <returns>
+        /// Returns the <see cref="IOperationResult"/> produced by <paramref name="func"/>
+        /// if the current result is a success; otherwise returns the current (failed) result.
+        /// If an exception implementing <see cref="IOperationError"/> is thrown it is wrapped
+        /// in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static IOperationResult Bind(this IOperationResult result, Func<IOperationResult> func)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(func, nameof(func));
 
+            try
+            {
+                if (result.IsSuccess())
+                    return func();
+
+                return result;
+            }
+            catch (Exception ex) when (ex is IOperationError)
+            {
+                return OperationResult.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Asynchronously executes the given function if the operation result is a success,
+        /// binding the result of the function to the current result chain.
+        /// </summary>
+        /// <param name="result">
+        /// The operation result to evaluate.
+        /// </param>
+        /// <param name="func">
+        /// An asynchronous function to invoke when the operation result is a success.
+        /// </param>
+        /// <returns>
+        /// Returns a <see cref="Task{TResult}"/> that resolves to the <see cref="IOperationResult"/>
+        /// produced by <paramref name="func"/> if the current result is a success; otherwise
+        /// resolves to the current (failed) result.
+        /// If an exception implementing <see cref="IOperationError"/> is thrown it is wrapped
+        /// in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static async Task<IOperationResult> BindAsync(this IOperationResult result, Func<Task<IOperationResult>> func)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(func, nameof(func));
+
+            try
+            {
+                if (result.IsSuccess())
+                    return await func().ConfigureAwait(false);
+
+                return result;
+            }
+            catch (Exception ex) when (ex is IOperationError)
+            {
+                return OperationResult.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Executes the given function if the operation result is a success,
+        /// binding the typed result of the function to the current result chain.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value that is expected to be returned by the next operation.
+        /// </typeparam>
+        /// <param name="result">
+        /// The operation result to evaluate.
+        /// </param>
+        /// <param name="func">
+        /// A function to invoke when the operation result is a success.
+        /// </param>
+        /// <returns>
+        /// Returns the <see cref="IOperationResult{T}"/> produced by <paramref name="func"/>
+        /// if the current result is a success; otherwise returns a failed <see cref="IOperationResult{T}"/>
+        /// carrying the original error.
+        /// If an exception implementing <see cref="IOperationError"/> is thrown it is wrapped
+        /// in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static IOperationResult<T> Bind<T>(this IOperationResult result, Func<IOperationResult<T>> func)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(func, nameof(func));
+
+            try
+            {
+                if (result.IsSuccess())
+                    return func();
+
+                return OperationResult<T>.Fail(result.Error!);
+            }
+            catch (Exception ex) when (ex is IOperationError)
+            {
+                return OperationResult<T>.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult<T>.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Asynchronously executes the given function if the operation result is a success,
+        /// binding the typed result of the function to the current result chain.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value that is expected to be returned by the next operation.
+        /// </typeparam>
+        /// <param name="result">
+        /// The operation result to evaluate.
+        /// </param>
+        /// <param name="func">
+        /// An asynchronous function to invoke when the operation result is a success.
+        /// </param>
+        /// <returns>
+        /// Returns a <see cref="Task{TResult}"/> that resolves to the <see cref="IOperationResult{T}"/>
+        /// produced by <paramref name="func"/> if the current result is a success; otherwise resolves to
+        /// a failed <see cref="IOperationResult{T}"/> carrying the original error.
+        /// If an exception implementing <see cref="IOperationError"/> is thrown it is wrapped
+        /// in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static async Task<IOperationResult<T>> BindAsync<T>(this IOperationResult result, Func<Task<IOperationResult<T>>> func)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(func, nameof(func));
+
+            try
+            {
+                if (result.IsSuccess())
+                    return await func().ConfigureAwait(false);
+
+                return OperationResult<T>.Fail(result.Error!);
+            }
+            catch (Exception ex) when (ex is IOperationError)
+            {
+                return OperationResult<T>.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult<T>.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Executes the given function with the value carried by the operation result
+        /// if the result is a success, binding the outcome to the current result chain.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value carried by the operation result.
+        /// </typeparam>
+        /// <param name="result">
+        /// The typed operation result to evaluate.
+        /// </param>
+        /// <param name="func">
+        /// A function that receives the value of the current result and produces
+        /// the next <see cref="IOperationResult"/> in the chain.
+        /// </param>
+        /// <returns>
+        /// Returns the <see cref="IOperationResult"/> produced by <paramref name="func"/>
+        /// if the current result is a success; otherwise returns the current (failed) result.
+        /// If an exception implementing <see cref="IOperationError"/> is thrown it is wrapped
+        /// in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static IOperationResult Bind<T>(this IOperationResult<T> result, Func<T?, IOperationResult> func)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(func, nameof(func));
+
+            try
+            {
+                if (result.IsSuccess())
+                    return func(result.Value);
+
+                return result;
+            }
+            catch (Exception ex) when (ex is IOperationError)
+            {
+                return OperationResult.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Asynchronously executes the given function with the value carried by the operation result
+        /// if the result is a success, binding the outcome to the current result chain.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value carried by the operation result.
+        /// </typeparam>
+        /// <param name="result">
+        /// The typed operation result to evaluate.
+        /// </param>
+        /// <param name="func">
+        /// An asynchronous function that receives the value of the current result and produces
+        /// the next <see cref="IOperationResult"/> in the chain.
+        /// </param>
+        /// <returns>
+        /// Returns a <see cref="Task{TResult}"/> that resolves to the <see cref="IOperationResult"/>
+        /// produced by <paramref name="func"/> if the current result is a success; otherwise resolves
+        /// to the current (failed) result.
+        /// If an exception implementing <see cref="IOperationError"/> is thrown it is wrapped
+        /// in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static async Task<IOperationResult> BindAsync<T>(this IOperationResult<T> result, Func<T?, Task<IOperationResult>> func)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(func, nameof(func));
+
+            try
+            {
+                if (result.IsSuccess())
+                    return await func(result.Value).ConfigureAwait(false);
+
+                return result;
+            }
+            catch (Exception ex) when (ex is IOperationError)
+            {
+                return OperationResult.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Executes a side-effect action on the operation result without altering the result,
+        /// and then returns the same result.
+        /// </summary>
+        /// <param name="result">
+        /// The operation result to pass to the action.
+        /// </param>
+        /// <param name="action">
+        /// An action to invoke with the current operation result, regardless of its state.
+        /// </param>
+        /// <returns>
+        /// Returns the same <see cref="IOperationResult"/> that was passed in, allowing further
+        /// chaining. If the action throws an exception implementing <see cref="IOperationError"/>
+        /// it is wrapped in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static IOperationResult Tap(this IOperationResult result, Action<IOperationResult> action)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(action, nameof(action));
+
+            try
+            {
+                action(result);
+                return result;
+            }
+            catch (Exception ex) when(ex is IOperationError)
+            {
+                return OperationResult.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Asynchronously executes a side-effect action on the operation result without altering
+        /// the result, and then returns the same result.
+        /// </summary>
+        /// <param name="result">
+        /// The operation result to pass to the action.
+        /// </param>
+        /// <param name="action">
+        /// An asynchronous action to invoke with the current operation result, regardless of its state.
+        /// </param>
+        /// <returns>
+        /// Returns a <see cref="Task{TResult}"/> that resolves to the same <see cref="IOperationResult"/>
+        /// that was passed in, allowing further chaining. If the action throws an exception implementing
+        /// <see cref="IOperationError"/> it is wrapped in a failed result; any other unhandled exception
+        /// is also wrapped as a failure.
+        /// </returns>
+        public static async Task<IOperationResult> TapAsync(this IOperationResult result, Func<IOperationResult, Task> action)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(action, nameof(action));
+
+            try
+            {
+                await action(result).ConfigureAwait(false);
+                return result;
+            }
+            catch (Exception ex) when(ex is IOperationError)
+            {
+                return OperationResult.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Executes a side-effect action on the typed operation result without altering the result,
+        /// and then returns the same result.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value carried by the operation result.
+        /// </typeparam>
+        /// <param name="result">
+        /// The typed operation result to pass to the action.
+        /// </param>
+        /// <param name="action">
+        /// An action to invoke with the current typed operation result, regardless of its state.
+        /// </param>
+        /// <returns>
+        /// Returns the same <see cref="IOperationResult{T}"/> that was passed in, allowing further
+        /// chaining. If the action throws an exception implementing <see cref="IOperationError"/>
+        /// it is wrapped in a failed result; any other unhandled exception is also wrapped as a failure.
+        /// </returns>
+        public static IOperationResult<T> Tap<T>(this IOperationResult<T> result, Action<IOperationResult<T>> action)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(action, nameof(action));
+
+            try
+            {
+                action(result);
+                return result;
+            }
+            catch (Exception ex) when(ex is IOperationError)
+            {
+                return OperationResult<T>.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult<T>.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
+        /// <summary>
+        /// Asynchronously executes a side-effect action on the typed operation result without
+        /// altering the result, and then returns the same result.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of the value carried by the operation result.
+        /// </typeparam>
+        /// <param name="result">
+        /// The typed operation result to pass to the action.
+        /// </param>
+        /// <param name="action">
+        /// An asynchronous action to invoke with the current typed operation result, regardless of its state.
+        /// </param>
+        /// <returns>
+        /// Returns a <see cref="Task{TResult}"/> that resolves to the same <see cref="IOperationResult{T}"/>
+        /// that was passed in, allowing further chaining. If the action throws an exception implementing
+        /// <see cref="IOperationError"/> it is wrapped in a failed result; any other unhandled exception
+        /// is also wrapped as a failure.
+        /// </returns>
+        public static async Task<IOperationResult<T>> TapAsync<T>(this IOperationResult<T> result, Func<IOperationResult<T>, Task> action)
+        {
+            Check.ThrowIfNull(result, nameof(result));
+            Check.ThrowIfNull(action, nameof(action));
+
+            try
+            {
+                await action(result).ConfigureAwait(false);
+                return result;
+            }
+            catch (Exception ex) when(ex is IOperationError)
+            {
+                return OperationResult<T>.Fail((IOperationError) ex);
+            }
+            catch (Exception ex)
+            {
+                return OperationResult<T>.Fail(
+                    "UnhandledException", 
+                    "RESULT", 
+                    "An unhandled exception occurred while executing the operation.",
+                    ex.AsOperationError());
+            }
+        }
+        
         /// <summary>
         /// Attempts to match the operation result to a specific state
         /// that can be handled by the caller.

--- a/test/Deveel.Results.XUnit/ExceptionExtensionsTests.cs
+++ b/test/Deveel.Results.XUnit/ExceptionExtensionsTests.cs
@@ -1,0 +1,538 @@
+namespace Deveel;
+
+public static class ExceptionExtensionsTests
+{
+    #region Basic Conversion Tests
+
+    [Fact]
+    public static void AsOperationError_WithSimpleException_CreatesOperationError()
+    {
+        var exception = new InvalidOperationException("Test error message");
+
+        var error = exception.AsOperationError();
+
+        Assert.NotNull(error);
+        Assert.IsType<OperationError>(error);
+        Assert.Equal("ERROR", error.Code);
+        Assert.Equal("Test error message", error.Message);
+        Assert.Equal("System", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithCustomCode_UsesProvidedCode()
+    {
+        var exception = new ArgumentException("Invalid argument");
+
+        var error = exception.AsOperationError("INVALID_ARG");
+
+        Assert.NotNull(error);
+        Assert.Equal("INVALID_ARG", error.Code);
+        Assert.Equal("Invalid argument", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithCustomDomain_UsesProvidedDomain()
+    {
+        var exception = new NullReferenceException("Object is null");
+
+        var error = exception.AsOperationError("ERROR", "CustomDomain");
+
+        Assert.NotNull(error);
+        Assert.Equal("ERROR", error.Code);
+        Assert.Equal("CustomDomain", error.Domain);
+        Assert.Equal("Object is null", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithCodeAndDomain_UsesBothParameters()
+    {
+        var exception = new FormatException("Invalid format");
+
+        var error = exception.AsOperationError("FORMAT_ERROR", "Validation");
+
+        Assert.NotNull(error);
+        Assert.Equal("FORMAT_ERROR", error.Code);
+        Assert.Equal("Validation", error.Domain);
+        Assert.Equal("Invalid format", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithEmptyCode_DefaultsToError()
+    {
+        var exception = new IOException("File not found");
+
+        var error = exception.AsOperationError("");
+
+        Assert.Equal("ERROR", error.Code);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithWhitespaceCode_DefaultsToError()
+    {
+        var exception = new TimeoutException("Operation timed out");
+
+        var error = exception.AsOperationError("   ");
+
+        Assert.Equal("ERROR", error.Code);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithNullCode_DefaultsToError()
+    {
+        var exception = new NotImplementedException("Not yet implemented");
+
+        var error = exception.AsOperationError(null);
+
+        Assert.Equal("ERROR", error.Code);
+    }
+
+    #endregion
+
+    #region Domain Inference Tests
+
+    [Fact]
+    public static void AsOperationError_InfersNamespaceAsDomain()
+    {
+        var exception = new System.Collections.Generic.KeyNotFoundException("Key not found");
+
+        var error = exception.AsOperationError();
+
+        Assert.Equal("System.Collections.Generic", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithNullDomainParameter_InfersNamespace()
+    {
+        var exception = new System.IO.FileNotFoundException("File not found");
+
+        var error = exception.AsOperationError("FILE_ERROR", null);
+
+        Assert.Equal("System.IO", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithEmptyDomainParameter_UsesEmptyDomain()
+    {
+        var exception = new Exception("Test");
+
+        var error = exception.AsOperationError("TEST", "");
+
+        Assert.Equal("", error.Domain);
+    }
+
+    #endregion
+
+    #region Inner Exception Tests
+
+    [Fact]
+    public static void AsOperationError_WithInnerException_ConvertsInnerException()
+    {
+        var innerException = new ArgumentException("Invalid argument");
+        var outerException = new InvalidOperationException("Operation failed", innerException);
+
+        var error = outerException.AsOperationError("OUTER");
+
+        Assert.NotNull(error);
+        Assert.Equal("OUTER", error.Code);
+        Assert.Equal("Operation failed", error.Message);
+        Assert.NotNull(error.InnerError);
+        Assert.Equal("ERROR", error.InnerError.Code);
+        Assert.Equal("Invalid argument", error.InnerError.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithChainedInnerExceptions_ConvertsAllChain()
+    {
+        var innermost = new ArgumentException("Invalid argument");
+        var middle = new InvalidOperationException("Operation failed", innermost);
+        var outer = new SystemException("System error", middle);
+
+        var error = outer.AsOperationError("OUTER_ERROR");
+
+        Assert.NotNull(error);
+        Assert.Equal("OUTER_ERROR", error.Code);
+        
+        Assert.NotNull(error.InnerError);
+        Assert.Equal("ERROR", error.InnerError.Code);
+        
+        Assert.NotNull(error.InnerError.InnerError);
+        Assert.Equal("ERROR", error.InnerError.InnerError.Code);
+        
+        Assert.Null(error.InnerError.InnerError.InnerError);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithInnerException_PreservesDomainAcrossChain()
+    {
+        var innerException = new ArgumentException("Inner error");
+        var outerException = new InvalidOperationException("Outer error", innerException);
+
+        var error = outerException.AsOperationError("OUTER", "CustomDomain");
+
+        Assert.NotNull(error.InnerError);
+        // Inner exception should inherit the domain from the domain parameter
+        Assert.Equal("CustomDomain", error.InnerError.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithoutInnerException_InnerErrorIsNull()
+    {
+        var exception = new Exception("Standalone exception");
+
+        var error = exception.AsOperationError();
+
+        Assert.Null(error.InnerError);
+    }
+
+    #endregion
+
+    #region OperationError Input Tests
+
+    [Fact]
+    public static void AsOperationError_WithOperationException_ReturnsOperationError()
+    {
+        var operationException = new OperationException("OP_ERROR", "OpDomain", "Operation error");
+
+        var error = operationException.AsOperationError();
+
+        Assert.NotNull(error);
+        Assert.Equal("OP_ERROR", error.Code);
+        Assert.Equal("OpDomain", error.Domain);
+    }
+
+    #endregion
+
+    #region Message Handling Tests
+
+    [Fact]
+    public static void AsOperationError_WithNullMessage_CreatesError()
+    {
+        #pragma warning disable CS8625
+        var exception = new Exception(null);
+        #pragma warning restore CS8625
+
+        var error = exception.AsOperationError();
+
+        // Exception converts null message to empty string
+        Assert.NotNull(error);
+        Assert.Equal("ERROR", error.Code);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithEmptyMessage_PreservesEmpty()
+    {
+        var exception = new Exception("");
+
+        var error = exception.AsOperationError();
+
+        Assert.Equal("", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithComplexMessage_PreservesMessage()
+    {
+        var complexMessage = "Complex error: Object reference not set to an instance of an object. Stack trace: ...";
+        var exception = new Exception(complexMessage);
+
+        var error = exception.AsOperationError();
+
+        Assert.Equal(complexMessage, error.Message);
+    }
+
+    #endregion
+
+    #region Different Exception Types Tests
+
+    [Fact]
+    public static void AsOperationError_WithArgumentNullException_Converts()
+    {
+        var exception = new ArgumentNullException("paramName", "Parameter cannot be null");
+
+        var error = exception.AsOperationError("NULL_PARAM");
+
+        Assert.NotNull(error);
+        Assert.Equal("NULL_PARAM", error.Code);
+        Assert.Equal("System", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithIndexOutOfRangeException_Converts()
+    {
+        var exception = new IndexOutOfRangeException("Index out of range");
+
+        var error = exception.AsOperationError("INDEX_ERROR", "ArrayOps");
+
+        Assert.Equal("INDEX_ERROR", error.Code);
+        Assert.Equal("ArrayOps", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithDivideByZeroException_Converts()
+    {
+        var exception = new DivideByZeroException("Attempted to divide by zero");
+
+        var error = exception.AsOperationError("MATH_ERROR");
+
+        Assert.Equal("MATH_ERROR", error.Code);
+        Assert.Equal("Attempted to divide by zero", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithAggregateException_Converts()
+    {
+        var inner1 = new ArgumentException("Arg error");
+        var inner2 = new Exception("Generic error");
+        var aggregateException = new AggregateException("Multiple errors", inner1, inner2);
+
+        var error = aggregateException.AsOperationError("AGGREGATE");
+
+        Assert.Equal("AGGREGATE", error.Code);
+        Assert.NotNull(error.InnerError);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithHttpRequestException_Converts()
+    {
+        var exception = new System.Net.Http.HttpRequestException("Request failed");
+
+        var error = exception.AsOperationError("HTTP_ERROR");
+
+        Assert.Equal("HTTP_ERROR", error.Code);
+        Assert.Equal("System.Net.Http", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithTaskCanceledException_Converts()
+    {
+        var exception = new TaskCanceledException("Task was cancelled");
+
+        var error = exception.AsOperationError("CANCELLED");
+
+        Assert.Equal("CANCELLED", error.Code);
+        Assert.Equal("Task was cancelled", error.Message);
+    }
+
+    #endregion
+
+    #region Code Parameter Edge Cases
+
+    [Fact]
+    public static void AsOperationError_WithSingleCharCode_AcceptsCode()
+    {
+        var exception = new Exception("Error");
+
+        var error = exception.AsOperationError("E");
+
+        Assert.Equal("E", error.Code);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithVeryLongCode_AcceptsCode()
+    {
+        var exception = new Exception("Error");
+        var longCode = new string('X', 1000);
+
+        var error = exception.AsOperationError(longCode);
+
+        Assert.Equal(longCode, error.Code);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithSpecialCharactersInCode_Preserves()
+    {
+        var exception = new Exception("Error");
+        var specialCode = "ERROR_CODE-123!@#";
+
+        var error = exception.AsOperationError(specialCode);
+
+        Assert.Equal(specialCode, error.Code);
+    }
+
+    #endregion
+
+    #region Domain Parameter Edge Cases
+
+    [Fact]
+    public static void AsOperationError_WithDomainParameter_OverridesNamespace()
+    {
+        var exception = new System.IO.IOException("IO error");
+
+        var error = exception.AsOperationError("ERROR", "CustomDomain");
+
+        Assert.Equal("CustomDomain", error.Domain);
+    }
+
+    [Fact]
+    public static void AsOperationError_WithWhitespaceDomain_UsesWhitespace()
+    {
+        var exception = new Exception("Error");
+
+        var error = exception.AsOperationError("ERROR", "   ");
+
+        Assert.Equal("   ", error.Domain);
+    }
+
+    #endregion
+
+    #region Chaining and Composition Tests
+
+    [Fact]
+    public static void AsOperationError_ResultCanBeUsedInOperationResult()
+    {
+        var exception = new InvalidOperationException("Invalid operation");
+
+        var error = exception.AsOperationError("OP_FAILED");
+        var result = OperationResult.Fail(error);
+
+        Assert.True(result.IsError());
+        Assert.Equal("OP_FAILED", result.Error?.Code);
+        Assert.Equal("Invalid operation", result.Error?.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_ResultCanBeChainedWithGenericResult()
+    {
+        var exception = new ArgumentException("Missing required argument");
+
+        var error = exception.AsOperationError("ARG_MISSING", "Arguments");
+        var result = OperationResult<int>.Fail(error);
+
+        Assert.True(result.IsError());
+        Assert.Equal("ARG_MISSING", result.Error?.Code);
+    }
+
+    [Fact]
+    public static void AsOperationError_CanBeUsedInBindChain()
+    {
+        var divideByZeroEx = new DivideByZeroException("Cannot divide by zero");
+
+        var result = OperationResult.Success
+            .Bind(() =>
+            {
+                throw divideByZeroEx;
+            });
+
+        Assert.True(result.IsError());
+        Assert.Equal("UnhandledException", result.Error?.Code);
+    }
+
+    #endregion
+
+    #region Recursive Inner Exception Tests
+
+    [Fact]
+    public static void AsOperationError_WithMultipleLevelsOfInnerExceptions_ConvertsAll()
+    {
+        var level3 = new Exception("Level 3 error");
+        var level2 = new Exception("Level 2 error", level3);
+        var level1 = new Exception("Level 1 error", level2);
+
+        var error = level1.AsOperationError("LEVEL1");
+
+        var current = error;
+        int level = 1;
+        while (current != null && level <= 3)
+        {
+            Assert.NotNull(current);
+            level++;
+            current = current.InnerError;
+        }
+        Assert.Null(current);
+    }
+
+    [Fact]
+    public static void AsOperationError_InnerExceptionsPreserveOrder()
+    {
+        var ex3 = new Exception("Third");
+        var ex2 = new Exception("Second", ex3);
+        var ex1 = new Exception("First", ex2);
+
+        var error = ex1.AsOperationError("TOP");
+
+        Assert.Equal("First", error.Message);
+        Assert.NotNull(error.InnerError);
+        Assert.Equal("Second", error.InnerError.Message);
+        Assert.NotNull(error.InnerError.InnerError);
+        Assert.Equal("Third", error.InnerError.InnerError.Message);
+    }
+
+    #endregion
+
+    #region Real-World Scenario Tests
+
+    [Fact]
+    public static void AsOperationError_FileIOException_Scenario()
+    {
+        var exception = new System.IO.FileNotFoundException("File not found: config.json");
+
+        var error = exception.AsOperationError("FILE_NOT_FOUND", "FileSystem");
+
+        Assert.Equal("FILE_NOT_FOUND", error.Code);
+        Assert.Equal("FileSystem", error.Domain);
+        Assert.Contains("config.json", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_DatabaseException_Scenario()
+    {
+        var innerException = new Exception("Timeout expired");
+        var dbException = new Exception("Database connection failed", innerException);
+
+        var error = dbException.AsOperationError("DB_ERROR", "Database");
+
+        Assert.Equal("DB_ERROR", error.Code);
+        Assert.Equal("Database", error.Domain);
+        Assert.NotNull(error.InnerError);
+        Assert.Equal("Timeout expired", error.InnerError.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_ValidationException_Scenario()
+    {
+        var ex = new ArgumentException("Password must be at least 8 characters");
+
+        var error = ex.AsOperationError("VALIDATION_FAILED", "Security");
+
+        Assert.Equal("VALIDATION_FAILED", error.Code);
+        Assert.Equal("Security", error.Domain);
+        Assert.Contains("Password", error.Message);
+    }
+
+    [Fact]
+    public static void AsOperationError_NetworkException_Scenario()
+    {
+        var innerException = new TimeoutException("Request timeout");
+        var networkException = new System.Net.Http.HttpRequestException("Failed to connect to server", innerException);
+
+        var error = networkException.AsOperationError("NETWORK_ERROR", "Connectivity");
+
+        Assert.Equal("NETWORK_ERROR", error.Code);
+        Assert.Equal("Connectivity", error.Domain);
+        Assert.Contains("Failed to connect", error.Message);
+        Assert.NotNull(error.InnerError);
+    }
+
+    #endregion
+
+    #region Null Safety Tests
+
+    [Fact]
+    public static void AsOperationError_WithNullInnerException_HandlesGracefully()
+    {
+        var exception = new Exception("Test", null);
+
+        var error = exception.AsOperationError();
+
+        Assert.Null(error.InnerError);
+    }
+
+    #endregion
+}
+
+
+
+
+
+
+
+

--- a/test/Deveel.Results.XUnit/OperationResultBindAndTapTests.cs
+++ b/test/Deveel.Results.XUnit/OperationResultBindAndTapTests.cs
@@ -1,0 +1,957 @@
+namespace Deveel;
+
+public static class OperationResultBindAndTapTests
+{
+    #region Bind Tests - IOperationResult to IOperationResult
+
+    [Fact]
+    public static void Bind_WithSuccessResult_ExecutesFunction()
+    {
+        var result = OperationResult.Success;
+        var functionExecuted = false;
+
+        var bindResult = result.Bind(() =>
+        {
+            functionExecuted = true;
+            return OperationResult.Success;
+        });
+
+        Assert.True(functionExecuted);
+        Assert.True(bindResult.IsSuccess());
+    }
+
+    [Fact]
+    public static void Bind_WithSuccessResult_ReturnsNewResult()
+    {
+        var result = OperationResult.Success;
+        var expectedError = new OperationError("err.1", "test");
+
+        var bindResult = result.Bind(() => OperationResult.Fail(expectedError));
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal(expectedError.Code, bindResult.Error?.Code);
+        Assert.Equal(expectedError.Domain, bindResult.Error?.Domain);
+    }
+
+    [Fact]
+    public static void Bind_WithErrorResult_DoesNotExecuteFunction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult.Fail(error);
+        var functionExecuted = false;
+
+        var bindResult = result.Bind(() =>
+        {
+            functionExecuted = true;
+            return OperationResult.Success;
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsError());
+        Assert.Equal(error.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static void Bind_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult result = null!;
+
+        Assert.Throws<ArgumentNullException>(() => result.Bind(() => OperationResult.Success));
+    }
+
+    [Fact]
+    public static void Bind_WithNullFunction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult.Success;
+
+        Assert.Throws<ArgumentNullException>(() => result.Bind(null!));
+    }
+
+    [Fact]
+    public static void Bind_WithOperationErrorException_CatchesAndReturnsError()
+    {
+        var result = OperationResult.Success;
+        var exception = new OperationException("err.1", "test", "An error occurred");
+
+        var bindResult = result.Bind(() => throw exception);
+
+        Assert.True(bindResult.IsError());
+        Assert.NotNull(bindResult.Error);
+    }
+
+    [Fact]
+    public static void Bind_WithRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult.Success;
+
+        var bindResult = result.Bind(() => throw new InvalidOperationException("Something went wrong"));
+
+        Assert.True(bindResult.IsError());
+        Assert.NotNull(bindResult.Error);
+        Assert.Equal("UnhandledException", bindResult.Error.Code);
+    }
+
+    #endregion
+
+    #region BindAsync Tests - IOperationResult to Task<IOperationResult>
+
+    [Fact]
+    public static async Task BindAsync_WithSuccessResult_ExecutesFunction()
+    {
+        var result = OperationResult.Success;
+        var functionExecuted = false;
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            functionExecuted = true;
+            await Task.Delay(0);
+            return OperationResult.Success;
+        });
+
+        Assert.True(functionExecuted);
+        Assert.True(bindResult.IsSuccess());
+    }
+
+    [Fact]
+    public static async Task BindAsync_WithSuccessResult_ReturnsNewResult()
+    {
+        var result = OperationResult.Success;
+        var expectedError = new OperationError("err.1", "test");
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            await Task.Delay(0);
+            return OperationResult.Fail(expectedError);
+        });
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal(expectedError.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static async Task BindAsync_WithErrorResult_DoesNotExecuteFunction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult.Fail(error);
+        var functionExecuted = false;
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            functionExecuted = true;
+            await Task.Delay(0);
+            return OperationResult.Success;
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsError());
+    }
+
+    [Fact]
+    public static async Task BindAsync_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult result = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.BindAsync(async () =>
+        {
+            await Task.Delay(0);
+            return OperationResult.Success;
+        }));
+    }
+
+    [Fact]
+    public static async Task BindAsync_WithNullFunction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult.Success;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.BindAsync(null!));
+    }
+
+    [Fact]
+    public static async Task BindAsync_WithRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult.Success;
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            await Task.Delay(0);
+            throw new InvalidOperationException("Something went wrong");
+        });
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal("UnhandledException", bindResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region Bind<T> Tests - IOperationResult to IOperationResult<T>
+
+    [Fact]
+    public static void BindGeneric_WithSuccessResult_ExecutesFunction()
+    {
+        var result = OperationResult.Success;
+        var functionExecuted = false;
+
+        var bindResult = result.Bind(() =>
+        {
+            functionExecuted = true;
+            return OperationResult<int>.Success(42);
+        });
+
+        Assert.True(functionExecuted);
+        Assert.True(bindResult.IsSuccess());
+        Assert.Equal(42, bindResult.Value);
+    }
+
+    [Fact]
+    public static void BindGeneric_WithSuccessResult_ReturnsNewResult()
+    {
+        var result = OperationResult.Success;
+        var expectedError = new OperationError("err.1", "test");
+
+        var bindResult = result.Bind(() => OperationResult<string>.Fail(expectedError));
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal(expectedError.Code, bindResult.Error?.Code);
+        Assert.Null(bindResult.Value);
+    }
+
+    [Fact]
+    public static void BindGeneric_WithErrorResult_DoesNotExecuteFunction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult.Fail(error);
+        var functionExecuted = false;
+
+        var bindResult = result.Bind(() =>
+        {
+            functionExecuted = true;
+            return OperationResult<int>.Success(42);
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsError());
+        Assert.Equal(error.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static void BindGeneric_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult result = null!;
+
+        Assert.Throws<ArgumentNullException>(() => result.Bind(() => OperationResult<int>.Success(42)));
+    }
+
+    [Fact]
+    public static void BindGeneric_WithNullFunction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult.Success;
+
+        Assert.Throws<ArgumentNullException>(() => result.Bind(null!));
+    }
+
+    [Fact]
+    public static void BindGeneric_WithRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult.Success;
+
+        var bindResult = result.Bind(() => throw new InvalidOperationException("Something went wrong"));
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal("UnhandledException", bindResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region BindAsync<T> Tests - IOperationResult to Task<IOperationResult<T>>
+
+    [Fact]
+    public static async Task BindAsyncGeneric_WithSuccessResult_ExecutesFunction()
+    {
+        var result = OperationResult.Success;
+        var functionExecuted = false;
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            functionExecuted = true;
+            await Task.Delay(0);
+            return OperationResult<int>.Success(42);
+        });
+
+        Assert.True(functionExecuted);
+        Assert.True(bindResult.IsSuccess());
+        // Cast to check the value
+        var resultOfInt = (IOperationResult<int>)bindResult;
+        Assert.Equal(42, resultOfInt.Value);
+    }
+
+    [Fact]
+    public static async Task BindAsyncGeneric_WithSuccessResult_ReturnsNewResult()
+    {
+        var result = OperationResult.Success;
+        var expectedError = new OperationError("err.1", "test");
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            await Task.Delay(0);
+            return OperationResult<string>.Fail(expectedError);
+        });
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal(expectedError.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static async Task BindAsyncGeneric_WithErrorResult_DoesNotExecuteFunction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult.Fail(error);
+        var functionExecuted = false;
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            functionExecuted = true;
+            await Task.Delay(0);
+            return OperationResult<int>.Success(42);
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsError());
+    }
+
+    [Fact]
+    public static async Task BindAsyncGeneric_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult result = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.BindAsync(async () =>
+        {
+            await Task.Delay(0);
+            return OperationResult<int>.Success(42);
+        }));
+    }
+
+    [Fact]
+    public static async Task BindAsyncGeneric_WithNullFunction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult.Success;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.BindAsync(null!));
+    }
+
+    [Fact]
+    public static async Task BindAsyncGeneric_WithRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult.Success;
+
+        var bindResult = await result.BindAsync(async () =>
+        {
+            await Task.Delay(0);
+            throw new InvalidOperationException("Something went wrong");
+        });
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal("UnhandledException", bindResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region Bind<T> Tests - IOperationResult<T> to IOperationResult
+
+    [Fact]
+    public static void BindFromGeneric_WithSuccessResult_ExecutesFunction()
+    {
+        var result = OperationResult<int>.Success(42);
+        var functionExecuted = false;
+        int? receivedValue = null;
+
+        var bindResult = result.Bind((value) =>
+        {
+            functionExecuted = true;
+            receivedValue = value;
+            return OperationResult.Success;
+        });
+
+        Assert.True(functionExecuted);
+        Assert.Equal(42, receivedValue);
+        Assert.True(bindResult.IsSuccess());
+    }
+
+    [Fact]
+    public static void BindFromGeneric_WithSuccessResult_ReturnsNewResult()
+    {
+        var result = OperationResult<int>.Success(42);
+        var expectedError = new OperationError("err.1", "test");
+
+        var bindResult = result.Bind((value) => OperationResult.Fail(expectedError));
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal(expectedError.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static void BindFromGeneric_WithErrorResult_DoesNotExecuteFunction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult<int>.Fail(error);
+        var functionExecuted = false;
+
+        var bindResult = result.Bind((value) =>
+        {
+            functionExecuted = true;
+            return OperationResult.Success;
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsError());
+        Assert.Equal(error.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static void BindFromGeneric_WithNullValue_PassesNullToFunction()
+    {
+        IOperationResult<string?> result = OperationResult<string?>.Success(null);
+        string? receivedValue = "default";
+
+        var bindResult = result.Bind((value) =>
+        {
+            receivedValue = value;
+            return OperationResult.Success;
+        });
+
+        Assert.True(bindResult.IsSuccess());
+        Assert.Null(receivedValue);
+    }
+
+    [Fact]
+    public static void BindFromGeneric_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult<int> result = null!;
+
+        Assert.Throws<ArgumentNullException>(() => result.Bind(v => OperationResult.Success));
+    }
+
+    [Fact]
+    public static void BindFromGeneric_WithNullFunction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        Assert.Throws<ArgumentNullException>(() => result.Bind(null!));
+    }
+
+    [Fact]
+    public static void BindFromGeneric_WithRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        var bindResult = result.Bind((value) => throw new InvalidOperationException("Something went wrong"));
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal("UnhandledException", bindResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region BindAsync<T> Tests - IOperationResult<T> to Task<IOperationResult>
+
+    [Fact]
+    public static async Task BindAsyncFromGeneric_WithSuccessResult_ExecutesFunction()
+    {
+        var result = OperationResult<int>.Success(42);
+        var functionExecuted = false;
+        int? receivedValue = null;
+
+        var bindResult = await result.BindAsync(async (value) =>
+        {
+            functionExecuted = true;
+            receivedValue = value;
+            await Task.Delay(0);
+            return OperationResult.Success;
+        });
+
+        Assert.True(functionExecuted);
+        Assert.Equal(42, receivedValue);
+        Assert.True(bindResult.IsSuccess());
+    }
+
+    [Fact]
+    public static async Task BindAsyncFromGeneric_WithSuccessResult_ReturnsNewResult()
+    {
+        var result = OperationResult<int>.Success(42);
+        var expectedError = new OperationError("err.1", "test");
+
+        var bindResult = await result.BindAsync(async (value) =>
+        {
+            await Task.Delay(0);
+            return OperationResult.Fail(expectedError);
+        });
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal(expectedError.Code, bindResult.Error?.Code);
+    }
+
+    [Fact]
+    public static async Task BindAsyncFromGeneric_WithErrorResult_DoesNotExecuteFunction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult<int>.Fail(error);
+        var functionExecuted = false;
+
+        var bindResult = await result.BindAsync(async (value) =>
+        {
+            functionExecuted = true;
+            await Task.Delay(0);
+            return OperationResult.Success;
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsError());
+    }
+
+    [Fact]
+    public static async Task BindAsyncFromGeneric_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult<int> result = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.BindAsync(async v =>
+        {
+            await Task.Delay(0);
+            return OperationResult.Success;
+        }));
+    }
+
+    [Fact]
+    public static async Task BindAsyncFromGeneric_WithNullFunction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.BindAsync(null!));
+    }
+
+    [Fact]
+    public static async Task BindAsyncFromGeneric_WithRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        var bindResult = await result.BindAsync(async (value) =>
+        {
+            await Task.Delay(0);
+            throw new InvalidOperationException("Something went wrong");
+        });
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal("UnhandledException", bindResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region Tap Tests - IOperationResult
+
+    [Fact]
+    public static void Tap_WithSuccessResult_ExecutesAction()
+    {
+        var result = OperationResult.Success;
+        var actionExecuted = false;
+        IOperationResult? receivedResult = null;
+
+        var tapResult = result.Tap((r) =>
+        {
+            actionExecuted = true;
+            receivedResult = r;
+        });
+
+        Assert.True(actionExecuted);
+        Assert.NotNull(receivedResult);
+        Assert.True(tapResult.IsSuccess());
+    }
+
+    [Fact]
+    public static void Tap_WithErrorResult_ExecutesAction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult.Fail(error);
+        var actionExecuted = false;
+
+        var tapResult = result.Tap((r) =>
+        {
+            actionExecuted = true;
+        });
+
+        Assert.True(actionExecuted);
+        Assert.True(tapResult.IsError());
+    }
+
+    [Fact]
+    public static void Tap_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult result = null!;
+
+        Assert.Throws<ArgumentNullException>(() => result.Tap(r => { }));
+    }
+
+    [Fact]
+    public static void Tap_WithNullAction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult.Success;
+
+        Assert.Throws<ArgumentNullException>(() => result.Tap(null!));
+    }
+
+    [Fact]
+    public static void Tap_WithActionThrowingRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult.Success;
+
+        var tapResult = result.Tap((r) => throw new InvalidOperationException("Something went wrong"));
+
+        Assert.True(tapResult.IsError());
+        Assert.Equal("UnhandledException", tapResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region TapAsync Tests - IOperationResult
+
+    [Fact]
+    public static async Task TapAsync_WithSuccessResult_ExecutesAction()
+    {
+        var result = OperationResult.Success;
+        var actionExecuted = false;
+        IOperationResult? receivedResult = null;
+
+        var tapResult = await result.TapAsync(async (r) =>
+        {
+            actionExecuted = true;
+            receivedResult = r;
+            await Task.Delay(0);
+        });
+
+        Assert.True(actionExecuted);
+        Assert.NotNull(receivedResult);
+        Assert.True(tapResult.IsSuccess());
+    }
+
+    [Fact]
+    public static async Task TapAsync_WithErrorResult_ExecutesAction()
+    {
+        var error = new OperationError("err.1", "test");
+        IOperationResult result = OperationResult.Fail(error);
+        var actionExecuted = false;
+
+        var tapResult = await result.TapAsync(async (r) =>
+        {
+            actionExecuted = true;
+            await Task.Delay(0);
+        });
+
+        Assert.True(actionExecuted);
+        Assert.True(tapResult.IsError());
+    }
+    [Fact]
+    public static async Task TapAsync_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult result = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.TapAsync(async r => await Task.Delay(0)));
+    }
+
+    [Fact]
+    public static async Task TapAsync_WithNullAction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult.Success;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.TapAsync(null!));
+    }
+
+    [Fact]
+    public static async Task TapAsync_WithActionThrowingRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult.Success;
+
+        var tapResult = await result.TapAsync(async (r) =>
+        {
+            await Task.Delay(0);
+            throw new InvalidOperationException("Something went wrong");
+        });
+
+        Assert.True(tapResult.IsError());
+        Assert.Equal("UnhandledException", tapResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region Tap<T> Tests - IOperationResult<T>
+
+    [Fact]
+    public static void TapGeneric_WithSuccessResult_ExecutesAction()
+    {
+        var result = OperationResult<int>.Success(42);
+        var actionExecuted = false;
+        IOperationResult<int>? receivedResult = null;
+
+        var tapResult = result.Tap((r) =>
+        {
+            actionExecuted = true;
+            receivedResult = r;
+        });
+
+        Assert.True(actionExecuted);
+        Assert.NotNull(receivedResult);
+        Assert.True(tapResult.IsSuccess());
+        Assert.Equal(42, tapResult.Value);
+    }
+
+    [Fact]
+    public static void TapGeneric_WithErrorResult_ExecutesAction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult<int>.Fail(error);
+        var actionExecuted = false;
+
+        var tapResult = result.Tap((r) =>
+        {
+            actionExecuted = true;
+        });
+
+        Assert.True(actionExecuted);
+        Assert.True(tapResult.IsError());
+    }
+
+    [Fact]
+    public static void TapGeneric_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult<int> result = null!;
+
+        Assert.Throws<ArgumentNullException>(() => result.Tap(r => { }));
+    }
+
+    [Fact]
+    public static void TapGeneric_WithNullAction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        Assert.Throws<ArgumentNullException>(() => result.Tap((Action<IOperationResult<int>>)null!));
+    }
+
+    [Fact]
+    public static void TapGeneric_WithActionThrowingRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        var tapResult = result.Tap((r) => throw new InvalidOperationException("Something went wrong"));
+
+        Assert.True(tapResult.IsError());
+        Assert.Equal("UnhandledException", tapResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region TapAsync<T> Tests - IOperationResult<T>
+
+    [Fact]
+    public static async Task TapAsyncGeneric_WithSuccessResult_ExecutesAction()
+    {
+        var result = OperationResult<int>.Success(42);
+        var actionExecuted = false;
+        IOperationResult<int>? receivedResult = null;
+
+        var tapResult = await result.TapAsync(async (r) =>
+        {
+            actionExecuted = true;
+            receivedResult = r;
+            await Task.Delay(0);
+        });
+
+        Assert.True(actionExecuted);
+        Assert.NotNull(receivedResult);
+        Assert.True(tapResult.IsSuccess());
+        Assert.Equal(42, tapResult.Value);
+    }
+
+    [Fact]
+    public static async Task TapAsyncGeneric_WithErrorResult_ExecutesAction()
+    {
+        var error = new OperationError("err.1", "test");
+        var result = OperationResult<int>.Fail(error);
+        var actionExecuted = false;
+
+        var tapResult = await result.TapAsync(async (r) =>
+        {
+            actionExecuted = true;
+            await Task.Delay(0);
+        });
+
+        Assert.True(actionExecuted);
+        Assert.True(tapResult.IsError());
+    }
+
+    [Fact]
+    public static async Task TapAsyncGeneric_WithNullResult_ThrowsArgumentNullException()
+    {
+        IOperationResult<int> result = null!;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.TapAsync(async r => await Task.Delay(0)));
+    }
+
+    [Fact]
+    public static async Task TapAsyncGeneric_WithNullAction_ThrowsArgumentNullException()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => result.TapAsync((Func<IOperationResult<int>, Task>)null!));
+    }
+
+    [Fact]
+    public static async Task TapAsyncGeneric_WithActionThrowingRegularException_CatchesAndReturnsUnhandledError()
+    {
+        var result = OperationResult<int>.Success(42);
+
+        var tapResult = await result.TapAsync(async (r) =>
+        {
+            await Task.Delay(0);
+            throw new InvalidOperationException("Something went wrong");
+        });
+
+        Assert.True(tapResult.IsError());
+        Assert.Equal("UnhandledException", tapResult.Error?.Code);
+    }
+
+    #endregion
+
+    #region Chaining Tests
+
+    [Fact]
+    public static void Bind_CanBeChained()
+    {
+        var result = OperationResult.Success
+            .Bind(() => OperationResult<int>.Success(10))
+            .Bind((value) => value > 5 ? OperationResult.Success : OperationResult.Fail("err.1", "test"));
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public static void Tap_CanBeChained()
+    {
+        var tapExecutedCount = 0;
+        var result = OperationResult.Success
+            .Tap(r => tapExecutedCount++)
+            .Tap(r => tapExecutedCount++);
+
+        Assert.Equal(2, tapExecutedCount);
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public static void BindAndTap_CanBeChained()
+    {
+        var bindExecuted = false;
+        var tapExecuted = false;
+
+        var result = OperationResult.Success
+            .Bind(() =>
+            {
+                bindExecuted = true;
+                return OperationResult<int>.Success(42);
+            })
+            .Tap(r => tapExecuted = true)
+            .Bind(value => value > 0 ? OperationResult.Success : OperationResult.Fail("err.1", "test"));
+
+        Assert.True(bindExecuted);
+        Assert.True(tapExecuted);
+        Assert.True(result.IsSuccess());
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public static void Bind_WithUnchangedResult_DoesNotExecuteFunction()
+    {
+        var result = OperationResult.NotChanged;
+        var functionExecuted = false;
+
+        var bindResult = result.Bind(() =>
+        {
+            functionExecuted = true;
+            return OperationResult.Success;
+        });
+
+        Assert.False(functionExecuted);
+        Assert.True(bindResult.IsUnchanged());
+    }
+
+    [Fact]
+    public static void Tap_WithUnchangedResult_ExecutesAction()
+    {
+        IOperationResult result = OperationResult.NotChanged;
+        var actionExecuted = false;
+
+        var tapResult = result.Tap(r => actionExecuted = true);
+
+        Assert.True(actionExecuted);
+        Assert.True(tapResult.IsUnchanged());
+    }
+
+    [Fact]
+    public static void TapGeneric_WithUnchangedResult_ExecutesAction()
+    {
+        var result = OperationResult<int>.NotChanged(33);
+        var actionExecuted = false;
+        int? receivedValue = null;
+
+        var tapResult = result.Tap(r =>
+        {
+            actionExecuted = true;
+            receivedValue = r.Value;
+        });
+
+        Assert.True(actionExecuted);
+        Assert.Equal(33, receivedValue);
+        Assert.True(tapResult.IsUnchanged());
+    }
+
+    [Fact]
+    public static void Bind_HandlesNestedErrors()
+    {
+        var innerError = new OperationError("inner.err", "test", "Inner error");
+        var outerError = new OperationError("outer.err", "test", "Outer error", innerError);
+        var result = OperationResult.Fail(outerError);
+
+        var bindResult = result.Bind(() => OperationResult.Success);
+
+        Assert.True(bindResult.IsError());
+        Assert.Equal("outer.err", bindResult.Error?.Code);
+        Assert.NotNull(bindResult.Error?.InnerError);
+        Assert.Equal("inner.err", bindResult.Error.InnerError.Code);
+    }
+
+    #endregion
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This pull request introduces a new extension method to facilitate integration between exceptions and the railway-oriented pattern in the codebase. The main change is the addition of an `ExceptionExtensions` static class that provides a convenient way to convert exceptions into operation errors.

**Enhancements for exception handling:**

* Added a new static class `ExceptionExtensions` in `src/Deveel.Results/ExceptionExtensions.cs`, which introduces the `AsOperationError` extension method for `Exception`. This method converts any exception into an `IOperationError`, supporting recursive conversion of inner exceptions and allowing optional specification of error code and domain.… tests